### PR TITLE
Correction to show only the selected service props

### DIFF
--- a/example/App.js
+++ b/example/App.js
@@ -94,7 +94,7 @@ export default class App extends Component {
             <Text style={styles.closeButton}>{'CLOSE'}</Text>
           </TouchableOpacity>
 
-          <Text style={styles.json}>{JSON.stringify(services, null, 2)}</Text>
+          <Text style={styles.json}>{JSON.stringify(service, null, 2)}</Text>
         </SafeAreaView>
       )
     }


### PR DESCRIPTION
When more than one service is resolved and you select one, the example shows all resolved services props.
Corrected to show only the selected service props.